### PR TITLE
Update koka grammar to maintained repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ in {
 | tree-sitter-kdl | [1.1.0](https://github.com/tree-sitter-grammars/tree-sitter-kdl/tree/v1.1.0) |
 | tree-sitter-kitty | [0.0.1](https://github.com/OXY2DEV/tree-sitter-kitty/tree/v0.0.1) |
 | tree-sitter-kittyconf | [2023-03-24](https://github.com/clo4/tree-sitter-kitty-conf/tree/9cdf551522d509c0432f136eb373bdf2e6032493) |
-| tree-sitter-koka | [2025-07-26](https://github.com/mtoohey31/tree-sitter-koka/tree/6dce132911ac375ac1a3591c868c47a2a84b30aa) |
+| tree-sitter-koka | [2026-02-13](https://github.com/koka-community/tree-sitter-koka/tree/33df0ee12208058a02acfa1843f087a63cec4441) |
 | tree-sitter-kos | [2026-01-04](https://github.com/kos-lang/tree-sitter-kos/tree/03b261c1a78b71c38cf4616497f253c4a4ce118b) |
 | tree-sitter-kotlin | [0.3.8](https://github.com/fwcd/tree-sitter-kotlin/tree/0.3.8) |
 | tree-sitter-koto | [0.16.0](https://github.com/koto-lang/tree-sitter-koto/tree/v0.16.0) |

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -2783,12 +2783,12 @@
     };
   };
   "tree-sitter-koka" = {
-    version = "unstable-2025-07-26";
+    version = "unstable-2026-02-13";
     src = fetchFromGitHub {
-      owner = "mtoohey31";
+      owner = "koka-community";
       repo = "tree-sitter-koka";
-      rev = "6dce132911ac375ac1a3591c868c47a2a84b30aa";
-      hash = "sha256-QXKfXg1qs3HNvjk1J8Kzm6uwR0frXXEONlJQPCqioNA=";
+      rev = "33df0ee12208058a02acfa1843f087a63cec4441";
+      hash = "sha256-XnmusI32yWA4ki7xOnJOmxvG0kMVLETCyWMyVzsx7nE=";
     };
   };
   "tree-sitter-kos" = {

--- a/update.py
+++ b/update.py
@@ -433,7 +433,7 @@ GRAMMARS: dict[str, Grammar] = {
     "tree-sitter-kdl": Grammar("https://github.com/tree-sitter-grammars/tree-sitter-kdl"),
     "tree-sitter-kitty": Grammar("https://github.com/OXY2DEV/tree-sitter-kitty"),
     "tree-sitter-kittyconf": Grammar("https://github.com/clo4/tree-sitter-kitty-conf"),
-    "tree-sitter-koka": Grammar("https://github.com/mtoohey31/tree-sitter-koka"),
+    "tree-sitter-koka": Grammar("https://github.com/koka-community/tree-sitter-koka"),
     "tree-sitter-kos": Grammar("https://github.com/kos-lang/tree-sitter-kos"),
     "tree-sitter-kotlin": Grammar("https://github.com/fwcd/tree-sitter-kotlin"),
     "tree-sitter-koto": Grammar("https://github.com/koto-lang/tree-sitter-koto"),


### PR DESCRIPTION
Hello! We moved the repository to a different organization [here](https://github.com/koka-community/tree-sitter-koka), so this PR updates things to reflect that.

I wasn't able to get the update script to work (ran into the rate limit) so I made the changes manually; hopefully that's OK.